### PR TITLE
Revert "fix: CSS-wide keywords in `@keyframes` cannot be unquoted"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5396,77 +5396,37 @@ mod tests {
   fn test_keyframes() {
     minify_test(
       r#"
-      @keyframes "test" {
+      @keyframes test {
+        from {
+          background: green;
+        }
+
+        50% {
+          background: red;
+        }
+
         100% {
           background: blue
         }
       }
     "#,
-      "@keyframes test{to{background:#00f}}",
+      "@keyframes test{0%{background:green}50%{background:red}to{background:#00f}}",
     );
     minify_test(
       r#"
       @keyframes test {
+        from {
+          background: green;
+          background-color: red;
+        }
+
         100% {
           background: blue
         }
       }
     "#,
-      "@keyframes test{to{background:#00f}}",
+      "@keyframes test{0%{background:red}to{background:#00f}}",
     );
-
-    // CSS-wide keywords and `none` cannot remove quotes.
-    minify_test(
-      r#"
-      @keyframes "revert" {
-        from {
-          background: green;
-        }
-      }
-    "#,
-      "@keyframes \"revert\"{0%{background:green}}",
-    );
-
-    minify_test(
-      r#"
-      @keyframes "none" {
-        from {
-          background: green;
-        }
-      }
-    "#,
-      "@keyframes \"none\"{0%{background:green}}",
-    );
-
-    // CSS-wide keywords without quotes throws an error.
-    error_test(
-      r#"
-      @keyframes revert {}
-    "#,
-      ParserError::UnexpectedToken(Token::Ident("revert".into())),
-    );
-
-    error_test(
-      r#"
-      @keyframes revert-layer {}
-    "#,
-      ParserError::UnexpectedToken(Token::Ident("revert-layer".into())),
-    );
-
-    error_test(
-      r#"
-      @keyframes none {}
-    "#,
-      ParserError::UnexpectedToken(Token::Ident("none".into())),
-    );
-
-    error_test(
-      r#"
-      @keyframes NONE {}
-    "#,
-      ParserError::UnexpectedToken(Token::Ident("NONE".into())),
-    );
-
     minify_test(
       r#"
       @-webkit-keyframes test {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -13,7 +13,7 @@ use crate::rules::{
   document::MozDocumentRule,
   font_face::{FontFaceDeclarationParser, FontFaceRule},
   import::ImportRule,
-  keyframes::{KeyframeListParser, KeyframesName, KeyframesRule},
+  keyframes::{KeyframeListParser, KeyframesRule},
   layer::LayerName,
   media::MediaRule,
   namespace::NamespaceRule,
@@ -122,7 +122,7 @@ pub enum AtRulePrelude<'i> {
   /// A @viewport rule prelude.
   Viewport(VendorPrefix),
   /// A @keyframes rule, with its animation name and vendor prefix if exists.
-  Keyframes(KeyframesName<'i>, VendorPrefix),
+  Keyframes(CustomIdent<'i>, VendorPrefix),
   /// A @page rule prelude.
   Page(Vec<PageSelector<'i>>),
   /// A @-moz-document rule.
@@ -425,8 +425,14 @@ impl<'a, 'o, 'b, 'i> AtRuleParser<'i> for NestedRuleParser<'a, 'o, 'i> {
           VendorPrefix::None
         };
 
-        let name = input.try_parse(KeyframesName::parse)?;
-        Ok(AtRulePrelude::Keyframes(name, prefix))
+        let location = input.current_source_location();
+        let name = match *input.next()? {
+          Token::Ident(ref s) => s.into(),
+          Token::QuotedString(ref s) => s.into(),
+          ref t => return Err(location.new_unexpected_token_error(t.clone())),
+        };
+
+        Ok(AtRulePrelude::Keyframes(CustomIdent(name), prefix))
       },
       "page" => {
         let selectors = input.try_parse(|input| input.parse_comma_separated(PageSelector::parse)).unwrap_or_default();

--- a/src/rules/keyframes.rs
+++ b/src/rules/keyframes.rs
@@ -15,7 +15,6 @@ use crate::traits::{Parse, ToCss};
 use crate::values::color::ColorFallbackKind;
 use crate::values::ident::CustomIdent;
 use crate::values::percentage::Percentage;
-use crate::values::string::CowArcStr;
 use crate::vendor_prefix::VendorPrefix;
 use cssparser::*;
 
@@ -24,76 +23,14 @@ use cssparser::*;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyframesRule<'i> {
   /// The animation name.
-  /// <keyframes-name> = <custom-ident> | <string>
   #[cfg_attr(feature = "serde", serde(borrow))]
-  pub name: KeyframesName<'i>,
+  pub name: CustomIdent<'i>,
   /// A list of keyframes in the animation.
   pub keyframes: Vec<Keyframe<'i>>,
   /// A vendor prefix for the rule, e.g. `@-webkit-keyframes`.
   pub vendor_prefix: VendorPrefix,
   /// The location of the rule in the source file.
   pub loc: Location,
-}
-
-/// KeyframesName
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum KeyframesName<'i> {
-  /// `<custom-ident>` of a `@keyframes` name.
-  #[cfg_attr(feature = "serde", serde(borrow))]
-  Ident(CustomIdent<'i>),
-
-  /// `<string>` of a `@keyframes` name.
-  #[cfg_attr(feature = "serde", serde(borrow))]
-  Custom(CowArcStr<'i>),
-}
-
-impl<'i> Parse<'i> for KeyframesName<'i> {
-  fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
-    match input.next()?.clone() {
-      Token::Ident(ref s) => {
-        // CSS-wide keywords without quotes throws an error.
-        match_ignore_ascii_case! { &*s,
-          "none" | "initial" | "inherit" | "unset" | "default" | "revert" | "revert-layer" => {
-            Err(input.new_unexpected_token_error(Token::Ident(s.clone())))
-          },
-          _ => {
-            Ok(KeyframesName::Ident(CustomIdent(s.into())))
-          }
-        }
-      }
-
-      Token::QuotedString(ref s) => Ok(KeyframesName::Custom(s.into())),
-      t => return Err(input.new_unexpected_token_error(t.clone())),
-    }
-  }
-}
-
-impl<'i> ToCss for KeyframesName<'i> {
-  fn to_css<W>(&self, dest: &mut Printer<W>) -> Result<(), PrinterError>
-  where
-    W: std::fmt::Write,
-  {
-    match self {
-      KeyframesName::Ident(ident) => {
-        dest.write_ident(ident.0.as_ref())?;
-      }
-      KeyframesName::Custom(s) => {
-        // CSS-wide keywords and `none` cannot remove quotes.
-        match_ignore_ascii_case! { &*s,
-          "none" | "initial" | "inherit" | "unset" | "default" | "revert" | "revert-layer" => {
-            dest.write_char('"')?;
-            dest.write_str(s.as_ref())?;
-            dest.write_char('"')?;
-          },
-          _ => {
-            dest.write_ident(s.as_ref())?;
-          }
-        }
-      }
-    }
-    Ok(())
-  }
 }
 
 impl<'i> KeyframesRule<'i> {

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -85,7 +85,6 @@ use nesting::NestingRule;
 use page::PageRule;
 use serde::Serialize;
 use std::collections::{HashMap, HashSet};
-use std::default::Default;
 use style::StyleRule;
 use supports::SupportsRule;
 use unknown::UnknownAtRule;
@@ -259,10 +258,7 @@ impl<'i> CssRuleList<'i> {
     for mut rule in self.0.drain(..) {
       match &mut rule {
         CssRule::Keyframes(keyframes) => {
-          if context
-            .unused_symbols
-            .contains(&keyframes.name.to_css_string(Default::default()).unwrap())
-          {
+          if context.unused_symbols.contains(keyframes.name.0.as_ref()) {
             continue;
           }
           keyframes.minify(context);


### PR DESCRIPTION
Reverts yisibl/parcel-css#1